### PR TITLE
fix: use explicit heading ids in glossary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@docusaurus/preset-classic": "2.2.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
-        "github-slugger": "^2.0.0",
         "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -8113,11 +8112,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/github-slugger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -22777,11 +22771,6 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
       }
-    },
-    "github-slugger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
     },
     "glob": {
       "version": "7.2.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@docusaurus/preset-classic": "2.2.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
-    "github-slugger": "^2.0.0",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/scripts/glossary-page.js
+++ b/scripts/glossary-page.js
@@ -44,7 +44,7 @@ function generateMarkdown (terms, frontmatter = GLOSSARY_META) {
     const termName = name || capitalize(id)
     const detailText = details || ''
     const s = stripIndents`
-    ### ${termName}
+    ### ${termName} {#${id}}
 
     > ${definition}
 

--- a/src/components/glossary/Term/index.tsx
+++ b/src/components/glossary/Term/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { usePluginData } from '@docusaurus/useGlobalData'
-import { slug } from 'github-slugger'
 
 import 'react-tooltip/dist/react-tooltip.css'
 import { Tooltip } from 'react-tooltip'
@@ -37,7 +36,7 @@ export default function Term (props: Props): React.ReactElement {
   }
 
   const t = matching[0]
-  const glossaryAnchor = slug(t.name ?? t.id)
+  const glossaryAnchor = t.id
 
   // generate unique anchor id, in case there are multiple Term components for the same term on the page
   const anchor = `term-${id}-${Math.random()}`


### PR DESCRIPTION
I was getting weird behavior for some of the glossary entries with the auto-generated heading ids (wrong ids, e.g. the heading for IPLD had the id "cid"). Turns out you can use [explicit heading ids](https://docusaurus.io/docs/markdown-features/toc#heading-ids), so I had the generator script do that. Seems to have cleared up the issue locally.