### PR TITLE
fix: replace react-tooltip with tippy.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,11 @@
         "@docusaurus/core": "2.2.0",
         "@docusaurus/preset-classic": "2.2.0",
         "@mdx-js/react": "^1.6.22",
+        "@tippyjs/react": "^4.2.6",
         "clsx": "^1.2.1",
         "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-tooltip": "^5.7.0",
         "yaml": "^2.2.1"
       },
       "devDependencies": {
@@ -2622,19 +2622,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ=="
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.0.tgz",
-      "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
-      "dependencies": {
-        "@floating-ui/core": "^1.0.5"
-      }
-    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -2959,6 +2946,15 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g=="
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -3255,6 +3251,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@tippyjs/react": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.2.6.tgz",
+      "integrity": "sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw==",
+      "dependencies": {
+        "tippy.js": "^6.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@trysound/sax": {
@@ -4927,11 +4935,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-css": {
       "version": "5.3.2",
@@ -13463,19 +13466,6 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-tooltip": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.7.0.tgz",
-      "integrity": "sha512-bkCwwwL1T1amT6cTiA5wPPBYZ3duVVC+5FY4ZHgQzRyuXb6SxRxPZNKMWh4eSyHjMiFTSg0hfBd8Pad9iuCnWg==",
-      "dependencies": {
-        "@floating-ui/dom": "^1.0.4",
-        "classnames": "^2.3.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.14.0",
-        "react-dom": ">=16.14.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -15420,6 +15410,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
+      }
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -18759,19 +18757,6 @@
         }
       }
     },
-    "@floating-ui/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ=="
-    },
-    "@floating-ui/dom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.0.tgz",
-      "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
-      "requires": {
-        "@floating-ui/core": "^1.0.5"
-      }
-    },
     "@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -19023,6 +19008,11 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g=="
     },
+    "@popperjs/core": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -19187,6 +19177,14 @@
       "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
       "requires": {
         "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@tippyjs/react": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.2.6.tgz",
+      "integrity": "sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw==",
+      "requires": {
+        "tippy.js": "^6.3.1"
       }
     },
     "@trysound/sax": {
@@ -20478,11 +20476,6 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
       "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w=="
-    },
-    "classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "clean-css": {
       "version": "5.3.2",
@@ -26462,15 +26455,6 @@
         "use-latest": "^1.2.1"
       }
     },
-    "react-tooltip": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.7.0.tgz",
-      "integrity": "sha512-bkCwwwL1T1amT6cTiA5wPPBYZ3duVVC+5FY4ZHgQzRyuXb6SxRxPZNKMWh4eSyHjMiFTSg0hfBd8Pad9iuCnWg==",
-      "requires": {
-        "@floating-ui/dom": "^1.0.4",
-        "classnames": "^2.3.2"
-      }
-    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -27893,6 +27877,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
+    "tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "requires": {
+        "@popperjs/core": "^2.9.0"
+      }
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "@docusaurus/core": "2.2.0",
     "@docusaurus/preset-classic": "2.2.0",
     "@mdx-js/react": "^1.6.22",
+    "@tippyjs/react": "^4.2.6",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-tooltip": "^5.7.0",
     "yaml": "^2.2.1"
   },
   "devDependencies": {

--- a/src/components/glossary/Term/index.tsx
+++ b/src/components/glossary/Term/index.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import { usePluginData } from '@docusaurus/useGlobalData'
-
-import 'react-tooltip/dist/react-tooltip.css'
-import { Tooltip } from 'react-tooltip'
+import Tippy from '@tippyjs/react'
 
 interface Props {
   id: string
@@ -21,7 +19,6 @@ interface PluginData {
 
 export default function Term (props: Props): React.ReactElement {
   const { id } = props
-
   const { terms } = usePluginData('w3up-glossary-plugin') as PluginData
 
   const glossaryRoute = '/glossary'
@@ -38,25 +35,20 @@ export default function Term (props: Props): React.ReactElement {
   const t = matching[0]
   const glossaryAnchor = t.id
 
-  // generate unique anchor id, in case there are multiple Term components for the same term on the page
-  const anchor = `term-${id}-${Math.random()}`
-
   if (t.definition == null) {
     console.error(`term ${id} has no "definition" field defined`)
     return <>{props.children}</>
   }
 
   return (
-    <>
+    <Tippy content={t.definition}>
       <a
-        id={anchor}
         className="glossary-term-link"
         data-tooltip-content={t.definition}
         href={`${glossaryRoute}#${glossaryAnchor}`}
         >
           {props.children}
       </a>
-      <Tooltip anchorId={anchor} />
-    </>
+    </Tippy>
   )
 }

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,0 +1,6 @@
+import React from 'react'
+import 'tippy.js/dist/tippy.css'
+
+export default function Root ({ children }) {
+  return <>{children}</>
+}


### PR DESCRIPTION
The weird glossary anchor bug in #19 seems to be caused by the react-tooltip component. Not sure why, but removing the component fixes the issue, and it comes back reliably as soon as you render a `Tooltip`.

This swaps out react-tooltip for tippy.js, which has a cuter name and is thus clearly superior anyway.

closes #19 